### PR TITLE
Migration to GitHub Actions

### DIFF
--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -1,0 +1,13 @@
+name: Check Releases
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+jobs:
+  check-releases:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: bash check-new-release
+        env:
+          GITHUBTOKEN: ${{ github.token }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-
-script:
-- bash check-new-release

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Regularly checks if a new upstream version is available for some applications, s
 Upstream version is compared with the one used in NethServer packages, such as [nethserver-mattermost](https://github.com/NethServer/nethserver-mattermost) and [nethserver-nextcloud](https://github.com/NethServer/nethserver-nextcloud).
 If upstream version is newer than NethServer one, an update issue is created in [NethServer issue tracker](https://github.com/NethServer/dev/issues) and a pull request is created in the corresponding NethServer repository.
 
-Version checks are performed daily by the Travis build.
+Version checks are performed daily by GitHub Actions.


### PR DESCRIPTION
When merged, a manual trigger build is advised to check if `github.token` has enough permissions to run the script.
NethServer/dev#6705