### PR TITLE
Fix GitHub Token permission

### DIFF
--- a/.github/workflows/daily-check.yml
+++ b/.github/workflows/daily-check.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: bash check-new-release
         env:
-          GITHUBTOKEN: ${{ github.token }}
+          GITHUBTOKEN: ${{ secrets.nethbot_token }}


### PR DESCRIPTION
Reverting the usage of a GitHub Token from the provided token in workflow to a secret
